### PR TITLE
Added a short comment to README.md regarding compiling IRBEM on Mac OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Installation
 IRBEM requires a Fortran compiler, and can be installed on most
 environments.
 
-Quick build procedure on Linux with gfortran:
+Quick build procedure on Linux and Mac OSX with gfortran:
 
     git clone https://github.com/PRBEM/IRBEM.git
 	cd IRBEM


### PR DESCRIPTION
# Summary
Given https://github.com/PRBEM/IRBEM/issues/15#issuecomment-871572452,  I successfully compiled IRBEM on my Mac. In this PR, I add a mention to README.md that the compilation steps for Linux should work on Mac OSX. This is a temporary fix; it will guide users away from the  misleading documentation in `make all.help`. A more permanent solution will involve cleaning up `Makefile` (see #16).

# Change
The only change is: "Quick build procedure on Linux with gfortran" -> "Quick build procedure on Linux and Mac OSX with gfortran" in README.md


# Testing
I did not do thorough testing, but the following commands ran successfully on my Mac running OSX.

```bash
make OS=linux64 ENV=gfortran64 all
make OS=linux64 ENV=gfortran64 install
```

I then installed the Python wrapper and  ran `test_IRBEM.py`. All but one unit test passed. One test failed because `make_lstar` returned slightly different model outputs than the Linux reference (see an example error below)

```
======================================================================
FAIL: test_lstar_time_str (__main__.TestIRBEM)
Test string time as a 'Time' column
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_IRBEM.py", line 75, in test_lstar_time_str
    self.assertAlmostEqualDict(self.model.make_lstar_output, self.l_star_true_dict)
  File "test_IRBEM.py", line 188, in assertAlmostEqualDict
    self.assertAlmostEqual(value_A, value_B)
AssertionError: 3.5597506994978874 != 3.5579374952779204 within 7 places (0.0018132042199670018 difference)
```

I wanted to add an OSX compilation test to the `compile.yml` GitHub Action, but I am unable to install `gfortran` with a GitHub Runner. My online search did not yield any solutions.